### PR TITLE
🐛 fix hrobotGetServerByName and hrobotGetServerByID server-type parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.0.10
+------
+ * Fixed a bug where a dedicated server could not be initialized if its type included a space, i.e. `Server Auction`
+ * Added another deployment sample (`deploy-k3s-sample.yml`) with updated `apiVersion` for `ClusterRoleBinding` (as `v1beta1` is unavailable with k3s v1.24), removed `PodSecurityPolicy` (as it is deprecated), changed secret references for the hcloud token (secret `hcloud` might already exist if Hetzners csi is installed) and increased reconciliation-period ([#403](https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/403))
+
+v0.0.9
+------
+
 v0.0.8
 ------
  * Fixed a bug where a dedicated server could be removed from the cluster if it was unavailable https://robot-ws.your-server.de/server

--- a/deploy/deploy-k3s-sample.yml
+++ b/deploy/deploy-k3s-sample.yml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hcloud
+  namespace: kube-system
+stringData:
+  token: YOURTOKEN # hcloud project token
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hrobot
+  namespace: kube-system
+stringData:
+  user: 'YOURROBOTUSER' # robot user
+  password: YOURROBOTPASSWORD # robot password
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hetzner-cloud-controller-manager
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:hetzner-cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: hetzner-cloud-controller-manager
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hetzner-cloud-controller-manager
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: hetzner-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: hetzner-cloud-controller-manager
+    spec:
+      serviceAccountName: hetzner-cloud-controller-manager
+      dnsPolicy: Default
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: Exists
+            - weight: 1
+              preference:
+                matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+      tolerations:
+        # Allow HCCM itself to schedule on nodes that have not yet been initialized by HCCM.
+        - key: "node.cloudprovider.kubernetes.io/uninitialized"
+          value: "true"
+          effect: "NoSchedule"
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+
+        # Allow HCCM to schedule on control plane nodes.
+        - key: "node-role.kubernetes.io/master"
+          effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
+
+        - key: "node.kubernetes.io/not-ready"
+          effect: "NoSchedule"
+      containers:
+        - image: ghcr.io/identw/hetzner-cloud-controller-manager:v0.0.10
+          name: hetzner-cloud-controller-manager
+          args:
+            - "--cloud-provider=hetzner"
+            - "--leader-elect=false"
+            - "--allow-untagged-cloud"
+            - "--route-reconciliation-period=30s"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HCLOUD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hcloud
+                  key: token
+            - name: HROBOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: hrobot
+                  key: user
+            - name: HROBOT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: hrobot
+                  key: password

--- a/hcloud/cloud.go
+++ b/hcloud/cloud.go
@@ -54,7 +54,7 @@ const (
 	hcloudLoadBalancersNetworkZone           = "HCLOUD_LOAD_BALANCERS_NETWORK_ZONE"
 	hcloudLoadBalancersDisablePrivateIngress = "HCLOUD_LOAD_BALANCERS_DISABLE_PRIVATE_INGRESS"
 	hcloudLoadBalancersUsePrivateIP          = "HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP"
-	providerVersion                          = "v0.0.8"
+	providerVersion                          = "v0.0.10"
 )
 
 var (

--- a/hcloud/util.go
+++ b/hcloud/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/identw/hetzner-cloud-controller-manager/internal/hcops"
@@ -93,11 +94,16 @@ func getServerByID(ctx context.Context, c commonClient, id int) (server *hcloud.
 func hrobotGetServerByName(name string) (*hcloud.Server, error) {
 	for _, s := range hrobotServers {
 		if s.Name == name {
+			escapedServerType := s.Type
+			// replace whitespaces in ServerType such as "Server Auction"
+			if regexp.MustCompile(`\s`).MatchString(escapedServerType) {
+				escapedServerType = strings.ReplaceAll(s.Type, " ", "-")
+			}
 			server := &hcloud.Server{
 				ID:         s.ID,
 				Name:       s.Name,
 				PublicNet:  hcloud.ServerPublicNet{IPv4: hcloud.ServerPublicNetIPv4{IP: s.IP}},
-				ServerType: &hcloud.ServerType{Name: s.Type},
+				ServerType: &hcloud.ServerType{Name: escapedServerType},
 				Status:     hcloud.ServerStatus("running"),
 				Datacenter: &hcloud.Datacenter{Location: &hcloud.Location{Name: s.Zone}, Name: s.Region},
 			}
@@ -111,11 +117,16 @@ func hrobotGetServerByName(name string) (*hcloud.Server, error) {
 func hrobotGetServerByID(id int) (*hcloud.Server, error) {
 	for _, s := range hrobotServers {
 		if s.ID == id {
+			escapedServerType := s.Type
+			// replace whitespaces in ServerType such as "Server Auction"
+			if regexp.MustCompile(`\s`).MatchString(escapedServerType) {
+				escapedServerType = strings.ReplaceAll(s.Type, " ", "-")
+			}
 			server := &hcloud.Server{
 				ID:         s.ID,
 				Name:       s.Name,
 				PublicNet:  hcloud.ServerPublicNet{IPv4: hcloud.ServerPublicNetIPv4{IP: s.IP}},
-				ServerType: &hcloud.ServerType{Name: s.Type},
+				ServerType: &hcloud.ServerType{Name: escapedServerType},
 				Status:     hcloud.ServerStatus("running"),
 				Datacenter: &hcloud.Datacenter{Location: &hcloud.Location{Name: s.Zone}, Name: s.Region},
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
 * Fixed a bug where a dedicated server could not be initialized if its type included a space, i.e. `Server Auction`
 * Added another deployment sample (`deploy-k3s-sample.yml`) with updated `apiVersion` for `ClusterRoleBinding` (as `v1beta1` is unavailable with k3s v1.24), removed `PodSecurityPolicy` (as it is deprecated), changed secret references for the hcloud token (secret `hcloud` might already exist if Hetzners csi is installed) and increased reconciliation-period ([#403](https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/403))

**Which issue(s) this PR fixes:**:
Fixes #11 